### PR TITLE
Solve 04-sfc

### DIFF
--- a/04-sfc/10-MeetupView-script-setup/MeetupAgenda.vue
+++ b/04-sfc/10-MeetupView-script-setup/MeetupAgenda.vue
@@ -1,19 +1,10 @@
-<script>
-import { defineComponent } from 'vue'
+<script setup>
 import MeetupAgendaItem from './MeetupAgendaItem.vue'
 
-export default defineComponent({
-  name: 'MeetupAgenda',
-
-  components: {
-    MeetupAgendaItem,
-  },
-
-  props: {
-    agenda: {
-      type: Array,
-      required: true,
-    },
+const { agenda } = defineProps({
+  agenda: {
+    type: Array,
+    required: true,
   },
 })
 </script>

--- a/04-sfc/10-MeetupView-script-setup/MeetupAgendaItem.vue
+++ b/04-sfc/10-MeetupView-script-setup/MeetupAgendaItem.vue
@@ -1,6 +1,13 @@
-<script>
-import { computed, defineComponent } from 'vue'
+<script setup>
+import { computed } from 'vue'
 import { UiIcon } from '@shgk/vue-course-ui'
+
+const { agendaItem } = defineProps({
+  agendaItem: {
+    type: Object,
+    required: true,
+  },
+})
 
 const agendaItemDefaultTitles = {
   registration: 'Регистрация',
@@ -24,29 +31,10 @@ const agendaItemIcons = {
   other: 'cal-sm',
 }
 
-export default defineComponent({
-  name: 'MeetupAgendaItem',
 
-  components: {
-    UiIcon,
-  },
 
-  props: {
-    agendaItem: {
-      type: Object,
-      required: true,
-    },
-  },
-
-  setup(props) {
-    const icon = computed(() => agendaItemIcons[props.agendaItem.type])
-    const title = computed(() => agendaItemDefaultTitles[props.agendaItem.type])
-    return {
-      icon,
-      title,
-    }
-  },
-})
+const icon = computed(() => agendaItemIcons[agendaItem.type])
+const title = computed(() => agendaItemDefaultTitles[agendaItem.type])
 </script>
 
 <template>

--- a/04-sfc/10-MeetupView-script-setup/MeetupCover.vue
+++ b/04-sfc/10-MeetupView-script-setup/MeetupCover.vue
@@ -1,26 +1,17 @@
-<script>
-import { computed, defineComponent } from 'vue'
+<script setup>
+import { computed } from 'vue'
 
-export default defineComponent({
-  name: 'MeetupCover',
-
-  props: {
-    title: {
-      type: String,
-    },
-
-    image: {
-      type: String,
-    },
+const { title, image } = defineProps({
+  title: {
+    type: String,
   },
 
-  setup(props) {
-    const bgStyle = computed(() => (props.image ? { '--bg-url': `url('${props.image}')` } : undefined))
-    return {
-      bgStyle,
-    }
+  image: {
+    type: String,
   },
 })
+
+const bgStyle = computed(() => (image ? { '--bg-url': `url('${image}')` } : undefined))
 </script>
 
 <template>

--- a/04-sfc/10-MeetupView-script-setup/MeetupDescription.vue
+++ b/04-sfc/10-MeetupView-script-setup/MeetupDescription.vue
@@ -1,13 +1,7 @@
-<script>
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  name: 'MeetupDescription',
-
-  props: {
-    description: {
-      type: String,
-    },
+<script setup>
+const { description } = defineProps({
+  description: {
+    type: String,
   },
 })
 </script>

--- a/04-sfc/10-MeetupView-script-setup/MeetupInfo.vue
+++ b/04-sfc/10-MeetupView-script-setup/MeetupInfo.vue
@@ -1,43 +1,29 @@
-<script>
-import { computed, defineComponent } from 'vue'
+<script setup>
+import { computed } from 'vue'
 import { UiIcon } from '@shgk/vue-course-ui'
 
-export default defineComponent({
-  name: 'MeetupInfo',
-
-  components: {
-    UiIcon,
+const { organizer, place, date } = defineProps({
+  organizer: {
+    type: String,
   },
 
-  props: {
-    organizer: {
-      type: String,
-    },
-
-    place: {
-      type: String,
-    },
-
-    date: {
-      type: Number,
-    },
+  place: {
+    type: String,
   },
 
-  setup(props) {
-    const isoDate = computed(() => new Date(props.date).toISOString().slice(0, 10))
-    const localDate = computed(() =>
-      new Date(props.date).toLocaleString(navigator.language, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      }),
-    )
-    return {
-      isoDate,
-      localDate,
-    }
+  date: {
+    type: Number,
   },
 })
+
+const isoDate = computed(() => new Date(date).toISOString().slice(0, 10))
+const localDate = computed(() =>
+  new Date(date).toLocaleString(navigator.language, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }),
+)
 </script>
 
 <template>

--- a/04-sfc/10-MeetupView-script-setup/MeetupView.vue
+++ b/04-sfc/10-MeetupView-script-setup/MeetupView.vue
@@ -1,46 +1,37 @@
-<script>
-import { defineComponent } from 'vue'
+<script setup>
 import { UiAlert, UiContainer } from '@shgk/vue-course-ui'
 import MeetupAgenda from './MeetupAgenda.vue'
 import MeetupDescription from './MeetupDescription.vue'
 import MeetupCover from './MeetupCover.vue'
 import MeetupInfo from './MeetupInfo.vue'
 
-export default defineComponent({
-  name: 'MeetupView',
-
-  components: {
-    UiAlert,
-    UiContainer,
+const { meetup } = defineProps({
+  meetup: {
+    type: Object,
+    required: true,
   },
 })
 </script>
 
 <template>
   <div>
-    <!-- Обложка митапа -->
-
-    <UiContainer>
-      <div class="meetup">
-        <div class="meetup__content">
-          <h2>Описание</h2>
-
-          <!-- Описание митапа -->
-
-          <h2>Программа</h2>
-
-          <!-- Программа митапа -->
-          <!-- Или при пустой программе - сообщение "Программа пока пуста..." в UiAlert -->
-          <UiAlert></UiAlert>
+      <MeetupCover :title="meetup.title" :image="meetup.image" />
+      <UiContainer>
+        <div class="meetup">
+          <div class="meetup__content">
+            <h2>Описание</h2>
+            <MeetupDescription :description="meetup.description" />
+            <h2>Программа</h2>
+            <MeetupAgenda v-if="meetup.agenda.length > 0" :agenda="meetup.agenda" />
+            <UiAlert v-else>Программа пока пуста...</UiAlert>
+          </div>
+          <div class="meetup__aside">
+            <MeetupInfo :organizer="meetup.organizer" :place="meetup.place" :date="meetup.date" />
+            <div class="meetup__aside-buttons"></div>
+          </div>
         </div>
-        <div class="meetup__aside">
-          <!-- Краткая информация о митапе -->
-
-          <div class="meetup__aside-buttons"></div>
-        </div>
-      </div>
-    </UiContainer>
-  </div>
+      </UiContainer>
+    </div>
 </template>
 
 <style scoped>
@@ -49,9 +40,6 @@ export default defineComponent({
   flex-direction: column-reverse;
   gap: var(--spacing-large);
   margin-block-start: var(--spacing-large);
-}
-
-.meetup__content {
 }
 
 .meetup__aside {

--- a/04-sfc/20-MeetupCover-style-v-bind/MeetupCover.vue
+++ b/04-sfc/20-MeetupCover-style-v-bind/MeetupCover.vue
@@ -11,7 +11,7 @@ const props = defineProps({
   },
 })
 
-const bgStyle = computed(() => (props.image ? { '--bg-url': `url('${props.image}')` } : undefined))
+const bgStyle = computed(() => (props.image ? `url("${props.image}")` : ''))
 </script>
 
 <template>
@@ -22,6 +22,7 @@ const bgStyle = computed(() => (props.image ? { '--bg-url': `url('${props.image}
 
 <style scoped>
 .meetup-cover {
+  --bg-url: v-bind('bgStyle');
   background-size: cover;
   background-position: center;
   /* Если изображение присутствует - берём его из CSS переменной, установленной на элемент в шаблоне */

--- a/04-sfc/30-UiStretch/UiStretch.vue
+++ b/04-sfc/30-UiStretch/UiStretch.vue
@@ -12,9 +12,10 @@
   height: 100%;
 }
 
-.stretch-container > img,
-.stretch-container > video,
-.stretch-container > picture {
+:slotted(img),
+:slotted(video),
+:slotted(picture) {
   object-fit: scale-down;
+
 }
 </style>


### PR DESCRIPTION
**Solve 04-sfc/10-MeetupView-script-setup**


**Solve 04-sfc/20-MeetupCover-style-v-bind**
Not entirely sure whether I handled absence of the image prop correctly

**Solve 04-sfc/30-UiStretch**
As slot content is considered to belong to the parent of the Component we can employ different tricks:
1. Use :deep() in the Component styles
Might be less fragile compared to option #2 in the wild, but still frowned upon
2. Use :slotted(). In this particular case it seems like the best use-case for :slotted feature. But it can target only direct children of a <slot/>.
Thus, in the wild might not be the best way as slot elements structure might change in the future and we will have to adjust the styles.
Anyhow, I decided to stick to this option just for the sake of practice :)
3. Style these elements in the parent. As far as I can tell this approach should be more maintainable due to the fact that parent owns slotted content and has full control over its structure.
4. Or even declare these styles in global styles. Can be used in certain scenarios when we have wider control of the project.